### PR TITLE
Add Stack project-level configuration

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+resolver: lts-21.13
+
+flags:
+  ghc-lib-parser-ex:
+    no-ghc-lib: true
+  hlint:
+    ghc-lib: false


### PR DESCRIPTION
Thank you for your very interesting [blog post](https://www.haskellforall.com/2023/09/ghc-plugin-for-hlint.html).

Footnote 4 referred to an interest in a working Stack build. I can build the package with this configuration file (which uses the most recent Stackage LTS Haskell snapshot, for GHC 9.4.7).

I also had success with using the plugin with Stack, with a simple single-package project, with `package.yaml`:
~~~yaml
name:                hlintPluginTest
version:             0.1.0.0

dependencies:
- base >= 4.7 && < 5
- hlint-plugin

ghc-options:
- -fplugin HLint.Plugin

library:
  source-dirs: src

executables:
  hlintPluginTest:
    main:                Main.hs
    source-dirs:         app
    ghc-options:
    - -threaded
    - -rtsopts
    - -with-rtsopts=-N
    dependencies:
    - hlintPluginTest
~~~

and `stack.yaml`:
~~~yaml
resolver: lts-21.13

extra-deps:
- hlint-plugin-1.0.2

flags:
  ghc-lib-parser-ex:
    no-ghc-lib: true
  hlint:
    ghc-lib: false
~~~

